### PR TITLE
Fix Issue#2 of poor contrast of window labels in activity menu.

### DIFF
--- a/themes/Xenlism-Minimalism/gnome-shell/gnome-shell.css
+++ b/themes/Xenlism-Minimalism/gnome-shell/gnome-shell.css
@@ -1063,10 +1063,13 @@ StScrollBar {
 .window-caption, .window-caption:hover {
   spacing: 25px;
   color: #4A4B4C;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(255, 255, 255, 0.7);
   border-radius: 2px;
   padding: 4px 12px;
   -shell-caption-spacing: 12px; }
+
+.window-caption:hover {
+  color: #5294E2; }
 
 .search-entry {
   width: 320px;


### PR DESCRIPTION
Set .window-caption background to theme's transparent white and made the label text the theme's blue on hover.

![activties-overview](https://cloud.githubusercontent.com/assets/205437/12662942/a1b1438e-c5d8-11e5-88cc-dbec90707a3e.png)
![activties-overview-hover](https://cloud.githubusercontent.com/assets/205437/12662948/a5d1f580-c5d8-11e5-9743-89c2765d4123.png)
